### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Stories in Ready](https://badge.waffle.io/cyberplanner/social_event_reminder.png?label=ready&title=Ready)](https://waffle.io/cyberplanner/social_event_reminder)
 # social_event_reminder
 Awesome social network for family members


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/cyberplanner/social_event_reminder

This was requested by a real person (user cyberplanner) on waffle.io, we're not trying to spam you.
